### PR TITLE
fix V1 and V2

### DIFF
--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -28,10 +28,14 @@ namespace CryptoNote {
     const uint64_t COIN = UINT64_C(100000);
     const uint64_t MINIMUM_FEE = UINT64_C(100);
 	          /* Fee adjustment V1 */
-    const uint64_t MINIMUM_FEE_V1                                = UINT64_C(0);
+    const uint64_t MINIMUM_FEE_V1                                = UINT64_C(10);
 
-    const uint64_t MINIMUM_FEE_V1_HEIGHT                         = 9777;
+    const uint64_t MINIMUM_FEE_V1_HEIGHT                         = 9338;
+                  /* Fee adjustment V2 */
+    const uint64_t MINIMUM_FEE_V2                                = UINT64_C(0);
 
+    const uint64_t MINIMUM_FEE_V2_HEIGHT                         = 9777;
+	  
     const uint64_t MINIMUM_FEE_BANKING = UINT64_C(100);
     const uint64_t POINT = UINT64_C(100);
     const uint64_t DEFAULT_DUST_THRESHOLD = UINT64_C(10);


### PR DESCRIPTION
	          /* Fee adjustment V1 */
    const uint64_t MINIMUM_FEE_V1                                = UINT64_C(0);

    const uint64_t MINIMUM_FEE_V1_HEIGHT                         = 9777;

V1 fee was at block 9338.  What are you doing???  You should include V1 and make this V2.  You will have to update other source files with V2 as well...